### PR TITLE
Implement basic TypeScript API skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# fast_mcp
+# Fast MCP Example
+
+This project demonstrates a simple API in TypeScript using Express and PostgreSQL. It stores prompts and their responses so that previous context can influence future requests.
+
+## Setup
+1. Install dependencies (requires Node 18 and npm):
+   ```bash
+   npm install
+   ```
+2. Provide a `.env` file with a `DATABASE_URL` connection string.
+3. Build and start the server:
+   ```bash
+   npm run build
+   npm start
+   ```
+
+The API exposes `/prompts` where you can `POST` new prompts and `GET` stored prompts.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "fast_mcp",
+  "version": "1.0.0",
+  "main": "dist/app.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/app.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "pg": "^8.11.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2"
+  }
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import promptRoutes from './routes/promptRoutes';
+
+const app = express();
+
+app.use(express.json());
+app.use('/prompts', promptRoutes);
+
+export default app;

--- a/src/config/db.ts
+++ b/src/config/db.ts
@@ -1,0 +1,10 @@
+import { Pool } from 'pg';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+export default pool;

--- a/src/controllers/promptController.ts
+++ b/src/controllers/promptController.ts
@@ -1,0 +1,25 @@
+import pool from '../config/db';
+import { Request, Response } from 'express';
+import { Prompt } from '../models/prompt';
+
+export async function createPrompt(req: Request, res: Response) {
+  const { question, answer } = req.body as Prompt;
+  try {
+    const result = await pool.query(
+      'INSERT INTO prompts (question, answer) VALUES ($1, $2) RETURNING *',
+      [question, answer]
+    );
+    res.json(result.rows[0]);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to save prompt' });
+  }
+}
+
+export async function listPrompts(req: Request, res: Response) {
+  try {
+    const result = await pool.query('SELECT * FROM prompts ORDER BY created_at DESC');
+    res.json(result.rows);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch prompts' });
+  }
+}

--- a/src/models/prompt.ts
+++ b/src/models/prompt.ts
@@ -1,0 +1,6 @@
+export interface Prompt {
+  id?: number;
+  question: string;
+  answer: string;
+  created_at?: Date;
+}

--- a/src/routes/promptRoutes.ts
+++ b/src/routes/promptRoutes.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { createPrompt, listPrompts } from '../controllers/promptController';
+
+const router = Router();
+
+router.post('/', createPrompt);
+router.get('/', listPrompts);
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,7 @@
+import app from './app';
+
+const PORT = process.env.PORT || 3000;
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
## Summary
- add TypeScript/express setup
- store prompts using PostgreSQL
- implement controllers and routes
- document setup instructions

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685fe3e94fc4832183e577c18589445f