### PR TITLE
Add embedding-based prompt search

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,6 @@ This project demonstrates a simple API in TypeScript using Express and PostgreSQ
    ```
 
 The API exposes `/prompts` where you can `POST` new prompts and `GET` stored prompts.
+When a prompt is saved the server now generates a simple text embedding which is stored alongside the record.
+Retrieval accepts an optional `q` query parameter. If provided, prompts are returned
+ordered by the cosine similarity between the stored embedding and the embedding of `q`.

--- a/src/controllers/promptController.ts
+++ b/src/controllers/promptController.ts
@@ -1,15 +1,17 @@
 import pool from '../config/db';
 import { Request, Response } from 'express';
 import { Prompt } from '../models/prompt';
+import { textEmbedding, cosineSimilarity } from '../utils/embedding';
 
 export async function createPrompt(req: Request, res: Response) {
   const { question, answer } = req.body as Prompt;
   try {
+    const embedding = textEmbedding(question);
     const result = await pool.query(
-      'INSERT INTO prompts (question, answer) VALUES ($1, $2) RETURNING *',
-      [question, answer]
+      'INSERT INTO prompts (question, answer, embedding) VALUES ($1, $2, $3) RETURNING *',
+      [question, answer, JSON.stringify(embedding)]
     );
-    res.json(result.rows[0]);
+    res.json({ ...result.rows[0], embedding });
   } catch (err) {
     res.status(500).json({ error: 'Failed to save prompt' });
   }
@@ -17,8 +19,21 @@ export async function createPrompt(req: Request, res: Response) {
 
 export async function listPrompts(req: Request, res: Response) {
   try {
-    const result = await pool.query('SELECT * FROM prompts ORDER BY created_at DESC');
-    res.json(result.rows);
+    const search = typeof req.query.q === 'string' ? req.query.q : undefined;
+    if (search) {
+      const queryEmbedding = textEmbedding(search);
+      const result = await pool.query('SELECT * FROM prompts');
+      const prompts = result.rows.map((row: any) => {
+        const emb: number[] = row.embedding ? JSON.parse(row.embedding) : [];
+        const similarity = cosineSimilarity(queryEmbedding, emb);
+        return { ...row, similarity };
+      });
+      prompts.sort((a, b) => b.similarity - a.similarity);
+      res.json(prompts);
+    } else {
+      const result = await pool.query('SELECT * FROM prompts ORDER BY created_at DESC');
+      res.json(result.rows);
+    }
   } catch (err) {
     res.status(500).json({ error: 'Failed to fetch prompts' });
   }

--- a/src/models/prompt.ts
+++ b/src/models/prompt.ts
@@ -2,5 +2,6 @@ export interface Prompt {
   id?: number;
   question: string;
   answer: string;
+  embedding?: number[];
   created_at?: Date;
 }

--- a/src/utils/embedding.ts
+++ b/src/utils/embedding.ts
@@ -1,0 +1,27 @@
+export function textEmbedding(text: string): number[] {
+  const counts = Array(26).fill(0);
+  for (const char of text.toLowerCase()) {
+    const code = char.charCodeAt(0);
+    if (code >= 97 && code <= 122) {
+      counts[code - 97] += 1;
+    }
+  }
+  const len = text.length || 1;
+  return counts.map((c) => c / len);
+}
+
+export function cosineSimilarity(a: number[], b: number[]): number {
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  const len = Math.min(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  if (normA === 0 || normB === 0) {
+    return 0;
+  }
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}


### PR DESCRIPTION
## Summary
- compute simple embeddings when prompts are stored
- compare embeddings to sort prompts when querying with `q` parameter
- document embedding search in README

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685fe5f9eb148321a900867628a1f82d