### PR TITLE
Use OpenAI embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@
 This project demonstrates a simple API in TypeScript using Express and PostgreSQL. It stores prompts and their responses so that previous context can influence future requests.
 
 ## Setup
-1. Install dependencies (requires Node 18 and npm):
+1. Install dependencies (requires Node 18 and npm). The project now relies on the
+   `openai` package:
    ```bash
    npm install
    ```
 2. Provide a `.env` file with a `DATABASE_URL` connection string.
+   Set `OPENAI_API_KEY` in the environment to enable embeddings.
 3. Build and start the server:
    ```bash
    npm run build

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "pg": "^8.11.1"
+    "pg": "^8.11.1",
+    "openai": "^4.28.0"
   },
   "devDependencies": {
     "typescript": "^5.2.2"

--- a/src/controllers/promptController.ts
+++ b/src/controllers/promptController.ts
@@ -1,15 +1,17 @@
 import pool from '../config/db';
 import { Request, Response } from 'express';
 import { Prompt } from '../models/prompt';
+import { fetchOpenAIEmbedding } from '../utils/embedding';
 
 export async function createPrompt(req: Request, res: Response) {
   const { question, answer } = req.body as Prompt;
   try {
+    const embedding = await fetchOpenAIEmbedding(question);
     const result = await pool.query(
       'INSERT INTO prompts (question, answer) VALUES ($1, $2) RETURNING *',
       [question, answer]
     );
-    res.json(result.rows[0]);
+    res.json({ ...result.rows[0], embedding });
   } catch (err) {
     res.status(500).json({ error: 'Failed to save prompt' });
   }
@@ -18,7 +20,13 @@ export async function createPrompt(req: Request, res: Response) {
 export async function listPrompts(req: Request, res: Response) {
   try {
     const result = await pool.query('SELECT * FROM prompts ORDER BY created_at DESC');
-    res.json(result.rows);
+    const prompts = await Promise.all(
+      result.rows.map(async (row: Prompt) => ({
+        ...row,
+        embedding: await fetchOpenAIEmbedding(row.question),
+      }))
+    );
+    res.json(prompts);
   } catch (err) {
     res.status(500).json({ error: 'Failed to fetch prompts' });
   }

--- a/src/utils/embedding.ts
+++ b/src/utils/embedding.ts
@@ -1,0 +1,25 @@
+import dotenv from 'dotenv';
+import OpenAI from 'openai';
+
+dotenv.config();
+
+const MODEL = 'text-embedding-ada-002';
+
+export async function fetchOpenAIEmbedding(text: string): Promise<number[]> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error('OPENAI_API_KEY is not defined');
+  }
+
+  const client = new OpenAI({ apiKey });
+  const response = await client.embeddings.create({
+    model: MODEL,
+    input: text,
+  });
+
+  if (!response.data[0]) {
+    throw new Error('No embedding returned');
+  }
+
+  return response.data[0].embedding;
+}


### PR DESCRIPTION
## Summary
- use `openai` npm package
- fetch embeddings with new `fetchOpenAIEmbedding` utility
- call `fetchOpenAIEmbedding` in prompt controller
- document `OPENAI_API_KEY` variable and dependency

## Testing
- `npm install openai` *(fails: 403 Forbidden)*
- `npm run build` *(fails: cannot find module 'express', 'pg', 'dotenv', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68617cfb8be48321aaf38e10b02040d1